### PR TITLE
feat: add copy buttons and attestation verify link

### DIFF
--- a/src/components/tabs/attestation-tab.tsx
+++ b/src/components/tabs/attestation-tab.tsx
@@ -6,12 +6,15 @@ import {
   getQuoteAction,
   infoAction,
 } from "@/app/actions/attestation";
+import type { GetQuoteResult } from "@/app/actions/attestation";
+import type { ActionResult } from "@/app/actions/keys";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { ResultPanel } from "@/components/result-panel";
+import { ExternalLink } from "lucide-react";
 
 export function AttestationTab() {
   return (
@@ -25,7 +28,7 @@ export function AttestationTab() {
 
 function GetQuoteCard() {
   const [reportData, setReportData] = useState("hello-dstack");
-  const [result, setResult] = useState<unknown>(null);
+  const [result, setResult] = useState<ActionResult<GetQuoteResult> | null>(null);
   const [pending, start] = useTransition();
   return (
     <Card>
@@ -53,6 +56,18 @@ function GetQuoteCard() {
         </Button>
         <Separator />
         <ResultPanel result={result} pending={pending} />
+        {result?.ok && (
+          <a
+            href={`https://proof.t16z.com/r?hex=${result.data.quote}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Button variant="outline" size="sm">
+              <ExternalLink className="size-3.5" />
+              Verify on proof.t16z.com
+            </Button>
+          </a>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/tabs/keys-tab.tsx
+++ b/src/components/tabs/keys-tab.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useCallback } from "react";
 import { getKeyAction, getTlsKeyAction } from "@/app/actions/keys";
+import type { ActionResult, GetKeyResult, GetTlsKeyResult } from "@/app/actions/keys";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -15,6 +16,24 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { ResultPanel } from "@/components/result-panel";
+import { Copy, Check } from "lucide-react";
+
+function CopyButton({ text, label }: { text: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [text]);
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleCopy}>
+      {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+      {label ?? "Copy"}
+    </Button>
+  );
+}
 
 export function KeysTab() {
   return (
@@ -29,7 +48,7 @@ function GetKeyCard() {
   const [path, setPath] = useState("wallet/eth");
   const [purpose, setPurpose] = useState("");
   const [algorithm, setAlgorithm] = useState("secp256k1");
-  const [result, setResult] = useState<unknown>(null);
+  const [result, setResult] = useState<ActionResult<GetKeyResult> | null>(null);
   const [pending, start] = useTransition();
 
   return (
@@ -81,6 +100,11 @@ function GetKeyCard() {
         </Button>
         <Separator />
         <ResultPanel result={result} pending={pending} />
+        {result?.ok && (
+          <div className="flex gap-2">
+            <CopyButton text={JSON.stringify(result.data, null, 2)} label="Copy Result" />
+          </div>
+        )}
       </CardContent>
     </Card>
   );
@@ -91,7 +115,7 @@ function GetTlsKeyCard() {
   const [altNames, setAltNames] = useState("localhost,127.0.0.1");
   const [usageRaTls, setUsageRaTls] = useState(false);
   const [withAppInfo, setWithAppInfo] = useState(false);
-  const [result, setResult] = useState<unknown>(null);
+  const [result, setResult] = useState<ActionResult<GetTlsKeyResult> | null>(null);
   const [pending, start] = useTransition();
 
   return (
@@ -158,6 +182,14 @@ function GetTlsKeyCard() {
         </Button>
         <Separator />
         <ResultPanel result={result} pending={pending} />
+        {result?.ok && (
+          <div className="flex gap-2">
+            <CopyButton text={JSON.stringify(result.data, null, 2)} label="Copy Result" />
+            {result.data.certificateChain[0] && (
+              <CopyButton text={result.data.certificateChain[0]} label="Copy Cert" />
+            )}
+          </div>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- Add copy-to-clipboard buttons for `getKey` and `getTlsKey` results in the Keys tab
- `getTlsKey` gets an extra "Copy Cert" button for `certificateChain[0]`
- Add "Verify on proof.t16z.com" link for `getQuote` results in the Attestation tab, opens `/r?hex=<quote>` in a new tab

## Test plan
- [ ] Click "Derive key" → verify "Copy Result" button appears and copies JSON to clipboard
- [ ] Click "Generate TLS key" → verify "Copy Result" and "Copy Cert" buttons both work
- [ ] Click "Generate quote" → verify "Verify on proof.t16z.com" link opens correct URL in new tab